### PR TITLE
Fix system order ambiguity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Plugin for PointCloudPlugin {
 
         render_app
             .add_system_to_stage(RenderStage::Extract, extract_point_cloud)
-            .add_system_to_stage(RenderStage::Prepare, prepare_point_cloud_bind_group)
+            .add_system_to_stage(RenderStage::Queue, prepare_point_cloud_bind_group)
             .add_system_to_stage(RenderStage::Queue, prepare_view_targets)
             .init_resource::<PointCloudBindGroup>()
             .insert_resource(point_cloud_pipeline);


### PR DESCRIPTION
Fixes https://github.com/ForesightMiningSoftwareCorporation/bevy_clipmap/issues/4

Bevy wants you to create bind groups in the Queue stage.  The dynamic uniform plugin insert the dynamic uniform components in the prepare stage.  So we can't use them in the prepare stage, otherwise we might get outdated info from last frame. Moving the bindgroup creation stage down solves the problem.

