### PR TITLE
Fix the shaders

### DIFF
--- a/src/shader.frag
+++ b/src/shader.frag
@@ -1,20 +1,13 @@
 #version 450
 
+#import bevy_render::view View
+
 layout(location = 0) out vec4 o_Target;
 layout(location = 1) out float o_Depth;
 layout(location = 0) in vec2 in_Point_Location;
 layout(location = 1) in vec3 in_Color;
 
-layout(set = 0, binding = 0) uniform View {
-    mat4 view_proj;
-    mat4 inverse_view_proj;
-    mat4 view;
-    mat4 inverse_view;
-    mat4 projection;
-    mat4 inverse_projection;
-    vec3 world_position;
-    vec4 viewport;
-};
+layout(set = 0, binding = 0) uniform View view;
 layout(set = 2, binding = 0) uniform Model {
     mat4 model_transform;
     float point_size;
@@ -29,11 +22,11 @@ void main()
 
     float depth = 1.0 / gl_FragCoord.w; // the world space depth
     
-    if (projection[2][3] != -1.0) {
+    if (view.projection[2][3] != -1.0) {
         // orthographic projection
         // projection[2][2] is r = 1.0 / (near - far).
         // This divides the depth offset by (near - far)
-        depth_offset *= projection[2][2];
+        depth_offset *= view.projection[2][2];
     }
 
 

--- a/src/shader.vert
+++ b/src/shader.vert
@@ -1,19 +1,14 @@
 #version 450
+
+#import bevy_render::view View
+
 layout(location = 0) in vec2 in_Position_Point;
 
 layout(location = 0) out vec2 out_Point_Location;
 layout(location = 1) out vec3 out_Color;
 
-layout(set = 0, binding = 0) uniform View {
-    mat4 view_proj;
-    mat4 inverse_view_proj;
-    mat4 view;
-    mat4 inverse_view;
-    mat4 projection;
-    mat4 inverse_projection;
-    vec3 world_position;
-    vec4 viewport;
-};
+layout(set = 0, binding = 0) uniform View view;
+
 struct ClippingPlane {
     vec3 origin;
     vec3 unit_normal;
@@ -81,7 +76,7 @@ void main() {
     in_Pos += interpolated;
     #endif
 
-    vec4 out_Pos = view_proj * model_transform * vec4(in_Pos, 1.0);
+    vec4 out_Pos = view.view_proj * model_transform * vec4(in_Pos, 1.0);
     if (clipping_planes.num_ranges > 0u) {
         vec4 worldPos4 = model_transform * vec4(in_Pos, 1.0);
         vec3 worldPos = worldPos4.xyz / worldPos4.w;
@@ -105,19 +100,19 @@ void main() {
 
 
     vec2 point_size = vec2(0.0, 0.0);
-    if (projection[2][3] == -1.0) {
+    if (view.projection[2][3] == -1.0) {
         // perspective projection
         float depth = out_Pos.w;
-        float one_over_slope = projection[1][1]; // (0.5 * fov_y_radians).tan()
+        float one_over_slope = view.projection[1][1]; // (0.5 * fov_y_radians).tan()
         point_size = vec2(0.5 * point_size_world_space * one_over_slope);
     } else {
         // orthographic projection
-        float a = 2.0 / projection[0][0]; // right - left
-        float b = 2.0 / projection[1][1]; // top - bottom
+        float a = 2.0 / view.projection[0][0]; // right - left
+        float b = 2.0 / view.projection[1][1]; // top - bottom
         float max_scale = max(abs(a), abs(b));
         point_size = vec2(point_size_world_space / max_scale);
     }
-    point_size.y *= viewport.z / viewport.w;
+    point_size.y *= view.viewport.z / view.viewport.w;
 
     out_Point_Location = in_Position_Point;
     gl_Position = out_Pos + vec4(in_Position_Point * point_size, 0.0, 0.0);


### PR DESCRIPTION
The view uniforms weren't updated during the update to bevy 0.11. This PR makes it so these use shader import statements instead, ensuring they will remain in sync.